### PR TITLE
Resolved 'failed to detect EUI verion: '

### DIFF
--- a/napalm_ftos/ftos.py
+++ b/napalm_ftos/ftos.py
@@ -320,7 +320,10 @@ class FTOSDriver(NetworkDriver):
             # cast some mac addresses
             for k in ['remote_port', 'remote_chassis_id']:
                 if len(lldp_entry[k].strip()) > 0:
-                    lldp_entry[k] = mac(lldp_entry[k])
+                    try:
+                        lldp_entry[k] = mac(lldp_entry[k])
+                    except:
+                        lldp_entry[k] = ''
 
             # transform capabilities
             for k in ['remote_system_capab', 'remote_system_enable_capab']:

--- a/napalm_ftos/ftos.py
+++ b/napalm_ftos/ftos.py
@@ -323,7 +323,7 @@ class FTOSDriver(NetworkDriver):
                     try:
                         lldp_entry[k] = mac(lldp_entry[k])
                     except:
-                        lldp_entry[k] = ''
+                        lldp_entry[k] = lldp_entry[k]
 
             # transform capabilities
             for k in ['remote_system_capab', 'remote_system_enable_capab']:


### PR DESCRIPTION
I resolved an issue of receiving a netaddr.core.AddrFormatError while using get_lldp_neighbors and get_lldp_neighbors_details with Netbox. It seems as though the mac addresses that were returned on line 323 would would throw a netaddr.core.AddrFormatError exception. So now instead of returning an error, it will return lldp_entry[k] as ' ' if it cannot parse the mac address.